### PR TITLE
Add WGET_OPTIONS to download EPIC_IMAGE

### DIFF
--- a/scripts/bluedata_install.sh
+++ b/scripts/bluedata_install.sh
@@ -249,7 +249,7 @@ ssh -o StrictHostKeyChecking=no -i "${LOCAL_SSH_PRV_KEY_PATH}" -T centos@${CTRL_
 
    echo "Downloading ${EPIC_DL_URL} to ${EPIC_FILENAME}"
 
-   wget -c --progress=bar -e dotbytes=10M -O ${EPIC_FILENAME} "${EPIC_DL_URL}"
+   wget -c --progress=bar -e dotbytes=10M -O ${EPIC_FILENAME} "${WGET_OPTIONS}" "${EPIC_DL_URL}"
    chmod +x ${EPIC_FILENAME}
 
    echo "Running EPIC install"


### PR DESCRIPTION
Enables injecting proxy setting (or other useful) options for wget to download $EPIC_FILENAME from $EPIC_DL_URL