### PR TITLE
Datatap setup for External MapR cluster fails

### DIFF
--- a/etc/postcreate.sh_template
+++ b/etc/postcreate.sh_template
@@ -91,8 +91,9 @@ if [[ "$MAPR_CLUSTER1_COUNT" == "3" ]]; then
    # Only run this on a 5.1 or lower installer.  Do not run this on 5.1.1+
    #./scripts/end_user_scripts/patch_datatap_5.1.1.sh
 
-   print_header "Setup Datatap to external MAPR cluster 1"
-   ./scripts/end_user_scripts/standalone_mapr/setup_datatap_5.1.sh
+   # Causes error as script requires TENANT_ID and script is also broken when TENANT_ID is provided (see comments)
+   #print_header "Setup Datatap to external MAPR cluster 1"
+   #./scripts/end_user_scripts/standalone_mapr/setup_datatap_5.1.sh
 
    print_header "Setup Fuse mount on RDP host to external MAPR cluster 1"
    ./scripts/end_user_scripts/standalone_mapr/setup_ubuntu_mapr_client.sh


### PR DESCRIPTION
```
=============================================================================================
Setup Datatap to external MAPR cluster 1
=============================================================================================
Usage: ./scripts/end_user_scripts/standalone_mapr/setup_datatap_5.1.sh TENANT_ID [ DEFAULT_MAPR_VMNT ]
Where: TENANT_ID = /api/v1/tenant/[0-9]*
erdinc-iam:~/environment/hcp-demo-env-aws-terraform (master) $

erdinc-iam:~/environment/hcp-demo-env-aws-terraform (master) $ hpecp tenant list
+------------------+----------------------+--------------------------------------------------------+--------+-------------+
|        id        |         name         |                      description                       | status | tenant_type |
+------------------+----------------------+--------------------------------------------------------+--------+-------------+
| /api/v1/tenant/1 |      Site Admin      |        Site Admin Tenant for BlueData clusters         | ready  |             |
| /api/v1/tenant/4 |     k8s-tenant-1     |                       dev tenant                       | ready  |     k8s     |
| /api/v1/tenant/3 | K8S Cluster Admin c1 | Kubernetes Cluster Admin Tenant for Kubernetes cluster | ready  |  k8s_admin  |
| /api/v1/tenant/2 |     Demo Tenant      |           Demo Tenant for BlueData Clusters            | ready  |   docker    |
+------------------+----------------------+--------------------------------------------------------+--------+-------------+
erdinc-iam:~/environment/hcp-demo-env-aws-terraform (master) $ ./scripts/end_user_scripts/standalone_mapr/setup_datatap_5.1.sh /api/v1/tenant/4
====================================================================================================================
Setting up DataTap to standalone MAPR
====================================================================================================================
MAPR_CLUSTER1_HOST=10.1.0.153
MAPR_USER=ad_admin1
MAPR_TCKT=ad_admin1_impersonation_ticket
MAPR_TCKT_PATH=/tmp/ad_admin1_impersonation_ticket
MAPR_VOL=demo_tenant_admins
MAPR_VMNT=/
MAPR_CLUSTER_NAME=demo1.mapr.com
MAPR_DTAP_NAME=ext-mapr
TENANT_KEYTAB_DIR=/srv/bluedata/keytab/4/
TENANT_KEYTAB_TCKT_FILE=/srv/bluedata/keytab/4/ad_admin1_impersonation_ticket
AD_ADMIN_GROUP=DemoTenantAdmins
AD_MEMBER_GROUP=DemoTenantUsers
--------------------------------------------------------------------------------------------------------------------------------------
Setting up mapr acls and volumes
--------------------------------------------------------------------------------------------------------------------------------------
MapR credentials of user 'mapr' for cluster 'demo1.mapr.com' are written to '/home/ubuntu/mapr_user_ticket'
--------------------------------------------------------------------------------------------------------------------------------------
Creating mapr ticket for ad_admin1
--------------------------------------------------------------------------------------------------------------------------------------
MapR credentials of user 'ad_admin1' for cluster 'demo1.mapr.com' are written to '/tmp/maprticket_1000'
Error in generating ticket as : null
erdinc-iam:~/environment/hcp-demo-env-aws-terraform (master) $
```